### PR TITLE
Add include <unistd.h>

### DIFF
--- a/include/simstring/memory_mapped_file_posix.h
+++ b/include/simstring/memory_mapped_file_posix.h
@@ -37,6 +37,7 @@
 #include <memory.h>
 #include <stdio.h>
 #include <stdlib.h>
+#include <unistd.h>
 #include <sys/types.h>
 #include <sys/stat.h>
 #include <sys/mman.h>


### PR DESCRIPTION
I added `#include <unistd.h>`
Because `::lseek` requires this header file, I couldn't build simstring in my environment.

http://man7.org/linux/man-pages/man2/lseek.2.html
