### PR TITLE
Prevent redefinition of NOMINMAX

### DIFF
--- a/include/simstring/memory_mapped_file_win32.h
+++ b/include/simstring/memory_mapped_file_win32.h
@@ -33,7 +33,9 @@
 #ifndef __MEMORY_MAPPED_FILE_WIN32_H__
 #define __MEMORY_MAPPED_FILE_WIN32_H__
 
+#ifndef NOMINMAX
 #define NOMINMAX    // To fix min/max conflicts with STL.
+#endif
 
 #include <memory.h>
 #include <windows.h>


### PR DESCRIPTION
Prevent redefinition of NOMINMAX when the project that includes the library already defines the symbol.
