### PR TITLE
Allow to install from pip

### DIFF
--- a/swig/Makefile.am
+++ b/swig/Makefile.am
@@ -2,7 +2,7 @@
 
 EXTRA_DIST = \
 	python/prepare.sh \
-	python/setup.py.in \
+	python/setup.py \
 	python/export_wrap.cpp \
 	python/simstring.py \
 	python/sample.py \

--- a/swig/python/prepare.sh
+++ b/swig/python/prepare.sh
@@ -1,9 +1,9 @@
-#!/bin/sh
+#!/bin/sh -xe
 # $Id:$
 
-ln -s ../export.cpp
-ln -s ../export.h
-ln -s ../export.i
+ln -sf ../export.cpp
+ln -sf ../export.h
+ln -sf ../export.i
 
 if [ "$1" = "--swig" ];
 then

--- a/swig/python/setup.py
+++ b/swig/python/setup.py
@@ -5,7 +5,9 @@ setup.py file for SWIG example
 """
 
 import sys
+import os
 import os.path
+import re
 
 def get_rootdir():
     return os.path.abspath(os.path.join(os.path.dirname(__file__), '../..'))
@@ -15,10 +17,24 @@ def get_includedir():
 def get_swigdir():
     return os.path.join(get_rootdir(), 'swig')
 
+def get_version():
+    with open(os.path.join(get_rootdir(), 'configure.in')) as f:
+        for line in f:
+            m = re.search(r'AM_INIT_AUTOMAKE\([^,]*,\s*([^)]+)\)', line)
+            if m:
+                return m.group(1)
+
 import os; os.environ['CC'] = 'g++'; os.environ['CXX'] = 'g++';
 os.environ['CPP'] = 'g++'; os.environ['LDSHARED'] = 'g++'
 
 from distutils.core import setup, Extension
+from distutils.command import build_ext as build_ext_module
+
+class build_ext(build_ext_module.build_ext):
+    def run(self):
+        prepare_script = os.path.abspath(os.path.join(os.path.dirname(__file__), 'prepare.sh'))
+        assert os.system(prepare_script + ' --swig') == 0
+        build_ext_module.build_ext.run(self)
 
 simstring_module = Extension(
     '_simstring',
@@ -27,16 +43,17 @@ simstring_module = Extension(
         'export_wrap.cpp',
         ],
     include_dirs=[get_includedir(),],
-    extra_link_args=['-shared', '-liconv', '-lpython'],
+    extra_link_args=['-shared'],
     language='c++',
     )
 
 setup(
-    name = '@PACKAGE@',
-    version = '@VERSION@',
+    name = 'simstring',
+    version = get_version(),
     author = 'Naoaki Okazaki',
     description = """SimString Python module""",
     ext_modules = [simstring_module],
     py_modules = ["simstring"],
+    cmdclass = {'build_ext': build_ext,},
     )
 


### PR DESCRIPTION
Currently, it is impossible to install simstring Python bindings directly from `pip` (e.g. via a `pip-requirements.txt` file in a project). It is currently necessary to manually clone the repository, run configure, enter the Python bindings directory, run `prepare.sh`, to finally be able to run `setup.py` or `pip`.

This patches fixes this issue by:
* Renaming `setup.py.in` to `setup.py`, removing thus the need to previously run `configure`. The package name is now static and the version is obtained by reading the `configure.in` file.
* Modifying `setup.py` so that it calls `prepare.sh` automatically as a pre-hook.

Besides that, this patch also:
* Improves `prepare.sh` error reporting, so that the user gets a meaningful error message if swig is missing from the system.
* Removes `-liconv -lpython` from `extra_link_args`. It is not necessary anymore to explicitly include these libraries (you can just assume they are loaded) - tested in Ubuntu LTS and Arch Linux. By removing them, simstring can be built for PyPy.

After this patch is merged, one will be able to install using `pip` by including the following line in their `pip-requirements.txt` file:

```
-e git+https://github.com/chokkan/simstring.git#egg=simstring&subdirectory=swig/python 
```

(you can test with my fork if you want to test before merging)