### PR TITLE
Fix regression in dice::min_size

### DIFF
--- a/include/simstring/measure.h
+++ b/include/simstring/measure.h
@@ -66,7 +66,7 @@ struct dice
 {
     inline static int min_size(int qsize, double alpha)
     {
-        return (int)std::ceil(alpha * qsize / (2. - qsize));
+        return (int)std::ceil(alpha * qsize / (2. - alpha));
     }
 
     inline static int max_size(int qsize, double alpha)


### PR DESCRIPTION
### Justification

The SimString paper ([link](http://www.aclweb.org/anthology/C10-1096)) defines the conditions for each similarity measure as follows:

![image](https://user-images.githubusercontent.com/22246447/118412915-3b20fd00-b662-11eb-832c-6f9c1d7ccb15.png)


The denominator in the min_size formula for Dice measure reads `(2-alpha)`, not `(2-|X|)`.